### PR TITLE
Only export Projection instance

### DIFF
--- a/src/EPSG_2056.js
+++ b/src/EPSG_2056.js
@@ -1,8 +1,6 @@
 import somerc from './somerc.js';
 import {create} from './utils.js';
 
-export const code = 'EPSG:2056';
-
 const def = `
   +proj=${somerc}
   +lat_0=46.95240555555556
@@ -17,6 +15,6 @@ const def = `
 `;
 const extent = [2420000, 1030000, 2900000, 1350000];
 
-export const proj = create(code, def, extent);
+const proj = create('EPSG:2056', def, extent);
 
-export default code;
+export default proj;

--- a/src/EPSG_2154.js
+++ b/src/EPSG_2154.js
@@ -1,8 +1,6 @@
 import lcc from './lcc.js';
 import {create} from './utils.js';
 
-export const code = 'EPSG:2154';
-
 const def = `
   +proj=${lcc}
   +lat_0=46.5
@@ -18,6 +16,6 @@ const def = `
 `;
 const extent = [-378305.81, 6093283.21, 1212610.74, 7186901.68];
 
-export const proj = create(code, def, extent);
+export const proj = create('EPSG:2154', def, extent);
 
-export default code;
+export default proj;

--- a/src/EPSG_21781.js
+++ b/src/EPSG_21781.js
@@ -1,8 +1,6 @@
 import somerc from './somerc.js';
 import {create} from './utils.js';
 
-export const code = 'EPSG:21781';
-
 const def = `
   +proj=${somerc}
   +lat_0=46.95240555555556
@@ -17,6 +15,6 @@ const def = `
 `;
 const extent = [420000, 30000, 900000, 350000];
 
-export const proj = create(code, def, extent);
+export const proj = create('EPSG:21781', def, extent);
 
-export default code;
+export default proj;

--- a/src/EPSG_27572.js
+++ b/src/EPSG_27572.js
@@ -1,8 +1,6 @@
 import lcc from './lcc.js';
 import {create} from './utils.js';
 
-export const code = 'EPSG:27572';
-
 const def = `
   +proj=${lcc}
   +lat_0=46.8
@@ -21,6 +19,6 @@ const def = `
 `;
 const extent = [5168.43, 1730142.53, 1013247.2, 2698564.2];
 
-export const proj = create(code, def, extent);
+export const proj = create('EPSG:27572', def, extent);
 
-export default code;
+export default proj;

--- a/src/EPSG_31254.js
+++ b/src/EPSG_31254.js
@@ -1,8 +1,6 @@
 import tmerc from './tmerc.js';
 import {create} from './utils.js';
 
-export const code = 'EPSG:31254';
-
 const def = ` 
   +proj=${tmerc}
   +lat_0=0
@@ -18,6 +16,6 @@ const def = `
 `;
 const extent = [-61758.89, 140394.51, 499917.82, 453931.14];
 
-export const proj = create(code, def, extent);
+export const proj = create('EPSG:31254', def, extent);
 
-export default code;
+export default proj;

--- a/src/EPSG_32631.js
+++ b/src/EPSG_32631.js
@@ -1,8 +1,6 @@
 import utm from './utm.js';
 import {create} from './utils.js';
 
-export const code = 'EPSG:32631';
-
 const def = `
   +proj=${utm}
   +zone=31
@@ -13,6 +11,6 @@ const def = `
 `;
 const extent = [166021.44, 0.0, 534994.66, 9329005.18];
 
-export const proj = create(code, def, extent);
+export const proj = create('EPSG:32631', def, extent);
 
-export default code;
+export default proj;

--- a/src/EPSG_3947.js
+++ b/src/EPSG_3947.js
@@ -1,8 +1,6 @@
 import lcc from './lcc.js';
 import {create} from './utils.js';
 
-export const code = 'EPSG:3947';
-
 const def = `
   +proj=${lcc}
   +lat_1=46.25
@@ -18,6 +16,6 @@ const def = `
 `;
 const extent = [619993.48, 5637784.91, 2212663.72, 6731809.22];
 
-export const proj = create(code, def, extent);
+export const proj = create('EPSG:3947', def, extent);
 
-export default code;
+export default proj;

--- a/src/EPSG_transform.test.js
+++ b/src/EPSG_transform.test.js
@@ -1,12 +1,10 @@
-import {
-  EPSG_2056,
-  EPSG_21781,
-  EPSG_2154,
-  EPSG_32631,
-  EPSG_27572,
-  EPSG_3947,
-  EPSG_31254,
-} from '.';
+import EPSG_2056 from './EPSG_2056';
+import EPSG_21781 from './EPSG_21781';
+import EPSG_2154 from './EPSG_2154';
+import EPSG_32631 from './EPSG_32631';
+import EPSG_27572 from './EPSG_27572';
+import EPSG_3947 from './EPSG_3947';
+import EPSG_31254 from './EPSG_31254';
 
 import {getTransform} from 'ol/proj.js';
 
@@ -63,10 +61,6 @@ const values = [{
 ];
 
 for (const spec of values) {
-  test(`have an EPSG code ${spec.code}`, () => {
-    expect(spec.import.code).toBe(spec.code);
-  });
-
   test(`transform from EPSG:4326 to ${spec.code} to be correct`, () => {
     const transform = getTransform('EPSG:4326', spec.code);
     const coords = transform(spec.lonlat);
@@ -82,7 +76,7 @@ for (const spec of values) {
   });
 
   test(`provide an OpenLayers projection for ${spec.code}`, () => {
-    const proj = spec.import.proj;
+    const proj = spec.import;
     expect(proj.getCode()).toBe(spec.code);
     expect(proj.getUnits()).toBe(spec.units);
     expect(proj.isGlobal()).toBe(spec.global);


### PR DESCRIPTION
This is breaking change, to be discussed.

old:
```js
import code, {proj} from '@geoblocks/proj/src/EPSG_2056.js';

const the_projection = proj;
const name = code;
```
new:
```js
import proj from '@geoblocks/proj/src/EPSG_2056.js';

const the_projection = proj;
const name = proj.getCode();
```


